### PR TITLE
remove no available tap

### DIFF
--- a/homebrew/Brewfile
+++ b/homebrew/Brewfile
@@ -1,6 +1,4 @@
 tap "homebrew/bundle"
-tap "homebrew/cask"
-tap "homebrew/cask-versions"
 tap "homebrew/core"
 brew "coreutils"
 brew "curl"


### PR DESCRIPTION
brew-cask tap is not available now. remove brew-cask tap from Brewfile.